### PR TITLE
Feat: update consume optional params

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -16,7 +16,7 @@ sh startup.sh
 /usr/bin/kafka-topics --zookeeper localhost:2181 --list
 
 # Consume messages from a topic --optional parameter: --max-message 10
-/usr/bin/kafka-console-consumer --bootstrap-server localhost:9092 --topic crimes.calls --from-beginning --max-message 10
+/usr/bin/kafka-console-consumer --bootstrap-server localhost:9092 --topic crimes.calls --from-beginning --max-messages 10
 
 #Run transformation and analytics on consumed messages
 spark-submit --packages org.apache.spark:spark-sql-kafka-0-10_2.11:2.3.4 --master local[*] data_stream.py


### PR DESCRIPTION
1.  Fix typo in consume kafka topic command
2. Rename runner to helpers to indicate purpose of script